### PR TITLE
typed Timestamp2

### DIFF
--- a/replication/row_event.go
+++ b/replication/row_event.go
@@ -605,7 +605,7 @@ func decodeBit(data []byte, nbits int, length int) (value int64, err error) {
 	return
 }
 
-func decodeTimestamp2(data []byte, dec uint16) (string, int, error) {
+func decodeTimestamp2(data []byte, dec uint16) (interface{}, int, error) {
 	//get timestamp binary length
 	n := int(4 + (dec+1)/2)
 	sec := int64(binary.BigEndian.Uint32(data[0:4]))
@@ -624,7 +624,7 @@ func decodeTimestamp2(data []byte, dec uint16) (string, int, error) {
 	}
 
 	t := time.Unix(sec, usec*1000)
-	return t.Format(TimeFormat), n, nil
+	return t, n, nil
 }
 
 const DATETIMEF_INT_OFS int64 = 0x8000000000


### PR DESCRIPTION
`decodeTimestamp2` only returns a string when the column value was `0000-00-00 00:00:00`. Otherwise -- when it is a "real" timestamp value, the function returns the `time.Time` type.

This allows us to retain the metadata associated with the value, i.e. timezone.
It also allows us to easily recognize a timestamp value where previously the `string` type would obscure the real column type.
