### PR TITLE
datetime returns secpart where available

### DIFF
--- a/replication/row_event.go
+++ b/replication/row_event.go
@@ -656,7 +656,7 @@ func decodeDatetime2(data []byte, dec uint16) (string, int, error) {
 	}
 
 	//ingore second part, no precision now
-	//var secPart int64 = tmp % (1 << 24)
+	var secPart int64 = tmp % (1 << 24)
 	ymdhms := tmp >> 24
 
 	ymd := ymdhms >> 17
@@ -671,6 +671,9 @@ func decodeDatetime2(data []byte, dec uint16) (string, int, error) {
 	minute := int((hms >> 6) % (1 << 6))
 	hour := int((hms >> 12))
 
+	if secPart != 0 {
+		return fmt.Sprintf("%04d-%02d-%02d %02d:%02d:%02d.%d", year, month, day, hour, minute, second, secPart), n, nil
+	}
 	return fmt.Sprintf("%04d-%02d-%02d %02d:%02d:%02d", year, month, day, hour, minute, second), n, nil
 }
 


### PR DESCRIPTION
If `DATETIME` includes a subsecond resolution value that is not `0`, then the returned value includes the subsecond precision & value.
